### PR TITLE
Include KOTLIN_VERSION variable into the kotlin-compiler download URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
    wget unzip
 
 ENV KOTLIN_VERSION 1.6.0
-RUN wget "https://github.com/JetBrains/kotlin/releases/download/v1.6.0/kotlin-compiler-${KOTLIN_VERSION}.zip" &&\
+RUN wget "https://github.com/JetBrains/kotlin/releases/download/v${KOTLIN_VERSION}/kotlin-compiler-${KOTLIN_VERSION}.zip" &&\
     unzip kotlin-compiler-${KOTLIN_VERSION}.zip -d / && mv /kotlinc /usr/lib/
 
 


### PR DESCRIPTION
Update the download link to include the `KOTLIN_VERSION` on the proper URL place.

**Docker Build result**
```
 => [internal] load build definition from Dockerfile                                                                             0.0s
 => => transferring dockerfile: 521B                                                                                             0.0s
 => [internal] load .dockerignore                                                                                                0.0s
 => => transferring context: 77B                                                                                                 0.0s
 => [internal] load metadata for docker.io/library/openjdk:17-slim                                                               2.0s
 => CACHED [build 1/3] FROM docker.io/library/openjdk:17-slim@sha256:aaa3b3cb27e3e520b8f116863d0580c438ed55ecfa0bc126b41f68c3f6  0.0s
 => [build 2/3] RUN apt-get update && apt-get -y --no-install-recommends install    wget unzip                                   5.4s
 => [build 3/3] RUN wget "https://github.com/JetBrains/kotlin/releases/download/v1.6.0/kotlin-compiler-1.6.0.zip" &&    unzip   20.2s
 => [run 2/2] COPY --from=build /usr/lib/kotlinc /usr/lib/kotlinc                                                                0.1s 
 => exporting to image                                                                                                           0.4s 
 => => exporting layers 
```

**Kotlin REPL output**
```
Welcome to Kotlin version 1.6.0 (JRE 17.0.2+8-86)
Type :help for help, :quit for quit
>>> 
```